### PR TITLE
DAT-19388 [DevOps] Fix terraform executable in GH

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -37,6 +37,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+          
       - name: Install spacectl
         uses: spacelift-io/setup-spacectl@main
         env:


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/generate.yml` file to set up Terraform. The most important change is the addition of a step to set up Terraform with a specific version.

Workflow updates:

* [`.github/workflows/generate.yml`](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aR40-R45): Added a step to set up Terraform using `hashicorp/setup-terraform@v3` with Terraform version `1.5.7`.