### PR TITLE
DAT-19531: update actions/upload-artifact and download-artifact

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -20,7 +20,7 @@ jobs:
       - id: set-matrix
         run: echo "matrix=$(cat commands.json)" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: commands-$LIQUIBASE_VERSION
           path: commands.json

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: commands-$LIQUIBASE_VERSION
           path: ./
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: commands-$LIQUIBASE_VERSION
           path: ./


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/generate.yml` file. The primary changes involve updating the versions of the `upload-artifact` and `download-artifact` actions.

Updates to GitHub Actions workflow:

* [`.github/workflows/generate.yml`](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aL23-R23): Updated `upload-artifact` action from version `v3` to `v4`.
* [`.github/workflows/generate.yml`](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aL51-R51): Updated `download-artifact` action from version `v3` to `v4` in two places. [[1]](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aL51-R51) [[2]](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aL122-R122)