### PR TITLE
Refactor push-to-repository script to use BASE_DIR for path resolution

### DIFF
--- a/scripts/push-to-repository.sh
+++ b/scripts/push-to-repository.sh
@@ -4,14 +4,16 @@ set -e
 
 if [[ -z "$BOT_TOKEN" ]]; then
   echo "Set the BOT_TOKEN env variable."
-	exit 1
+    exit 1
 fi
 
+# Store absolute paths at the beginning
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMMAND="${1/ /-}" #replace spaces with dashes
 TAG=$2
 REPO="https://liquibot:$BOT_TOKEN@github.com/liquibase-github-actions/$COMMAND.git"
-COMMAND_DIR="$PWD/action/${COMMAND//-/_}" #replace dashes with underscore
-TEMP_DIR="$PWD/action/temp"
+COMMAND_DIR="$BASE_DIR/action/${COMMAND//-/_}" #replace dashes with underscore
+TEMP_DIR="$BASE_DIR/action/temp"
 
 create_issue() {
   local COMMAND=$1
@@ -58,7 +60,7 @@ create_release() {
 cp $COMMAND_DIR/* $TEMP_DIR
 
 # Copy LICENSE file from root directory to temp dir
-cp $PWD/LICENSE $TEMP_DIR/
+cp $BASE_DIR/LICENSE $TEMP_DIR/
 
 if [[ `git status --porcelain` ]]; then
   # Commit new files


### PR DESCRIPTION
This pull request updates the `scripts/push-to-repository.sh` script to ensure consistent use of absolute paths for better reliability. The changes primarily involve replacing instances of `$PWD` with `$BASE_DIR`, which is initialized at the start of the script.

Path handling improvements:

* Added initialization of `BASE_DIR` to store the absolute path of the script's root directory and replaced `$PWD` with `$BASE_DIR` in the definitions of `COMMAND_DIR` and `TEMP_DIR`. (`[scripts/push-to-repository.shR10-R16](diffhunk://#diff-6a6842ebb59e6f7df93befdd5212ef515e80b4de154663f1db2356f7820baf88R10-R16)`)
* Updated the `create_release` function to use `$BASE_DIR` instead of `$PWD` when copying the `LICENSE` file, ensuring the correct file is referenced. (`[scripts/push-to-repository.shL61-R63](diffhunk://#diff-6a6842ebb59e6f7df93befdd5212ef515e80b4de154663f1db2356f7820baf88L61-R63)`)