### PR TITLE
DAT-20186 Update fossa_ai.yml

### DIFF
--- a/.github/workflows/fossa_ai.yml
+++ b/.github/workflows/fossa_ai.yml
@@ -14,4 +14,4 @@ jobs:
     with:
       check_snippets: true
       check_ai_generated_code: true
-      generate_sbom: true
+      generate_fossa_3p_license_report: true


### PR DESCRIPTION
This pull request updates the `.github/workflows/fossa_ai.yml` file to modify the configuration of the FOSSA AI job. The change replaces the generation of an SBOM (Software Bill of Materials) with the generation of a third-party license report.

* [`.github/workflows/fossa_ai.yml`](diffhunk://#diff-16fa3dae8fcf42e25227fd7efbf7683e56bb393265c17267bd5a6eada811edfeL17-R17): Replaced the `generate_sbom` parameter with `generate_fossa_3p_license_report` in the FOSSA AI job configuration.