### PR TITLE
🔧 DAT-20283: use GitHub App token and OpenTofu

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -5,12 +5,12 @@ on:
   workflow_dispatch:
 
 # Add permissions needed for the workflow
-permissions:
-  contents: write    # For checkout, pushing to repositories
-  actions: read      # For workflow operations
-  packages: write    # For package operations if needed
-  id-token: write    # For authentication operations
-  issues: write      # For creating issues if needed
+# permissions:
+#   contents: write    # For checkout, pushing to repositories
+#   actions: read      # For workflow operations
+#   packages: write    # For package operations if needed
+#   id-token: write    # For authentication operations
+#   issues: write      # For creating issues if needed
 
 env:
   LIQUIBASE_VERSION: 4.32.0
@@ -36,7 +36,6 @@ jobs:
 
   create-action-repo:
     env:
-      TF_VAR_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TF_TOKEN_spacelift_io: ${{ secrets.SPACELIFT_API_KEY }}
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
       SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
@@ -44,13 +43,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ create-command-list ]
     steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-workflows: write
+          permission-issues: write
+
       - uses: actions/checkout@v4
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
         with:
-          terraform_version: "1.5.7"
-          terraform_wrapper: false
+          tofu_version: "1.9.0"
           
       - name: Install spacectl
         uses: spacelift-io/setup-spacectl@main
@@ -62,22 +71,32 @@ jobs:
           name: commands-$LIQUIBASE_VERSION
           path: ./
 
-      - name: Terraform Format
+      - name: OpenTofu Format
         id: fmt
-        run: terraform fmt
+        env:
+          TF_VAR_GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+        run: tofu fmt
 
-      - name: Terraform Init
+      - name: OpenTofu Init
         id: init
-        run: terraform init
+        env:
+          TF_VAR_GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+        run: tofu init
 
-      - name: Terraform Validate
+      - name: OpenTofu Validate
         id: validate
-        run: terraform validate -no-color
+        env:
+          TF_VAR_GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+        run: tofu validate -no-color
 
       - name: Preview infrastructure
+        env:
+            TF_VAR_GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
         run: spacectl stack local-preview --id liquibase-github-actions --disregard-gitignore=true
 
       - name: Mount commands.json
+        env:
+          TF_VAR_GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           spacectl stack environment mount --id liquibase-github-actions source/commands.json commands.json
 
@@ -87,6 +106,7 @@ jobs:
           SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
           SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
           SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+          TF_VAR_GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           spacectl stack set-current-commit --id liquibase-github-actions --sha ${{ github.sha }}
           spacectl stack deploy --id liquibase-github-actions --auto-confirm 
@@ -111,6 +131,17 @@ jobs:
 
       - run: make generate VERSION=$LIQUIBASE_VERSION COMMAND="${{ matrix.commands }}"
 
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: liquibase-github-actions
+          # permissions required to perform operations from push-to-repository.sh
+          permission-contents: write # Required for git push, tag, clone 
+          permission-issues: write # Required for creating issues
+
       - name: Configure git user
         run: |
           git config --global init.defaultBranch main
@@ -120,7 +151,7 @@ jobs:
       - name: Push Action to Repo
         run: ./scripts/push-to-repository.sh "${{ matrix.commands }}" $LIQUIBASE_VERSION
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
 
   output-action:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the `.github/workflows/generate.yml` file to replace Terraform with OpenTofu, improve GitHub App token handling, and streamline permissions. The changes enhance compatibility with OpenTofu and improve security by using dynamically generated tokens.

### Migration to OpenTofu:
* Replaced Terraform-related steps (`terraform fmt`, `terraform init`, `terraform validate`) with OpenTofu equivalents (`tofu fmt`, `tofu init`, `tofu validate`) and updated the setup action to `opentofu/setup-opentofu@v1`. [[1]](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aL39-R62) [[2]](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aL65-R99)

### Improved GitHub App Token Handling:
* Introduced a step to generate GitHub App tokens dynamically using `actions/create-github-app-token@v2` for enhanced security and functionality. Updated related environment variables to use the generated token. [[1]](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aL39-R62) [[2]](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aR109) [[3]](diffhunk://#diff-73a5f52e43cc725cdeb8ed4080bba34f1f18762a041836c2cfea3e2241f4070aL123-R154)

### Permissions Adjustments:
* Commented out the static permissions block to streamline workflow configuration and rely on dynamically generated tokens for required permissions.

**Tested half workflow:**

https://github.com/liquibase/github-action-generator/actions/runs/15286493129
<img width="1773" alt="Screenshot 2025-05-27 at 4 57 49 PM" src="https://github.com/user-attachments/assets/9dd73801-91e6-4714-8665-76bd0ce84fd2" />

the other job was skipped as we have if condition on main `github.ref == 'refs/heads/main'`