### PR TITLE
DAT-20283-GH-Terraform-app-auth

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,13 @@ terraform {
 }
 
 provider "github" {
-  token = var.GITHUB_TOKEN
   owner = "liquibase-github-actions"
+  app_auth {
+    id              = var.LIQUIBASE_TERRAFORM_GH_APP_ID
+    installation_id = var.LIQUIBASE_TERRAFORM_GH_INSTALL_ID_ACTIONS
+    pem_file        = file(var.LIQUIBASE_TERRAFORM_GH_APP_PRIVATE_KEY)
+  }
+  write_delay_ms = 200 # Performance tuning
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,15 @@
-# export TF_VAR_GITHUB_TOKEN="..."
-variable "GITHUB_TOKEN" {
-  type        = string
-  description = "LiquiBot GitHub Token"
+variable "GITHUB_OWNER" {
+  description = "GitHub Owner"
+}
+
+variable "LIQUIBASE_TERRAFORM_GH_APP_ID" {
+  description = "GitHub App ID"
+}
+
+variable "LIQUIBASE_TERRAFORM_GH_INSTALL_ID_ACTIONS" {
+  description = "GitHub App Installation ID"
+}
+
+variable "LIQUIBASE_TERRAFORM_GH_APP_PRIVATE_KEY" {
+  description = "GitHub App Private Key"
 }


### PR DESCRIPTION
This pull request updates the Terraform configuration to replace the use of a personal access token with GitHub App authentication for improved security and performance. It introduces new variables related to the GitHub App and removes the previous token-based authentication setup.

### Authentication changes:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL11-R17): Removed the `token` field from the `provider "github"` configuration and added an `app_auth` block with fields for `id`, `installation_id`, and `pem_file` to enable GitHub App authentication. Also added a `write_delay_ms` parameter for performance tuning.

* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL1-R14): Removed the `GITHUB_TOKEN` variable and added new variables: `LIQUIBASE_TERRAFORM_GH_APP_ID`, `LIQUIBASE_TERRAFORM_GH_INSTALL_ID_ACTIONS`, and `LIQUIBASE_TERRAFORM_GH_APP_PRIVATE_KEY` to support the GitHub App authentication setup. Also added a `GITHUB_OWNER` variable for specifying the repository owner.