### PR TITLE
TECHOPS-161: replace stale arduino/setup-protoc with apt protobuf-compiler

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -108,10 +108,9 @@ jobs:
       - run: echo ${{ matrix.commands }}
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: '3.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
 
       - run: make generate VERSION=$LIQUIBASE_VERSION COMMAND="${{ matrix.commands }}"
 


### PR DESCRIPTION
## Summary

Replace stale `arduino/setup-protoc@v3` (last push 2024-09-03) with the distro-packaged `protobuf-compiler` (apt). Resolves [TECHOPS-161](https://datical.atlassian.net/browse/TECHOPS-161), unblocks DAT-22654 allowlist cleanup.

## What changed

`.github/workflows/generate.yml` — the "Install Protoc" step:

| Before | After |
|---|---|
| `uses: arduino/setup-protoc@v3` with `version: '3.x'` and `repo-token` | `sudo apt-get update && sudo apt-get install -y protobuf-compiler` |

`protobuf-compiler` from the Ubuntu repo provides the `protoc` 3.x binary the workflow needs (`make generate` shells out to `protoc`). No GitHub-token rate-limit concerns since we're not pulling release artifacts via API.

## Note for reviewer

This repo is marked deprecated in `CLAUDE.md` (being replaced by `liquibase/setup-liquibase`) but isn't archived yet. While that migration is in flight, the supply-chain audit still applies — this PR is the minimum change to remove the archived-action dependency. If the repo is archived before this is merged, the PR can simply be closed.

## Test plan

- [ ] Workflow YAML parses
- [ ] Next workflow run installs `protoc` successfully and `make generate VERSION=$LIQUIBASE_VERSION COMMAND="..."` proceeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-161]: https://datical.atlassian.net/browse/TECHOPS-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ